### PR TITLE
source-viewer directive not being applied in descriptions

### DIFF
--- a/web/ngplugin.js
+++ b/web/ngplugin.js
@@ -268,6 +268,7 @@ angular.module('docular.plugin.ngdoc', [])
                 } else {
                     $element.append(template)
                 }
+                $compile($element)($scope);
             }
         };
     }])


### PR DESCRIPTION
source-viewer directive not being applied in descriptions

related issues:
https://github.com/Vertafore/docular-ng-plugin/issues/3
https://github.com/Vertafore/docular/issues/132