### PR TITLE
Revert "source-viewer directive not being applied in descriptions"

### DIFF
--- a/web/ngplugin.js
+++ b/web/ngplugin.js
@@ -268,7 +268,6 @@ angular.module('docular.plugin.ngdoc', [])
                 } else {
                     $element.append(template)
                 }
-                $compile($element)($scope);
             }
         };
     }])


### PR DESCRIPTION
Reverts Vertafore/docular-ng-plugin#6, due to #7